### PR TITLE
docs: document Supabase environment variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ tenderhub/
 
 - Always use the database schema defined in `database_structure.json`.
 
+## Environment Configuration
+
+- Подключение к базе данных Supabase хранится в корневом файле `.env`.
+- Используются переменные `NEXT_PUBLIC_SUPABASE_URL` и `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+
 ## Build, Test, and Development Commands
 
 ### Development


### PR DESCRIPTION
## Summary
- describe how to configure Supabase in `.env`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script "type-check")*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890ad4f2d60832ea2d85e6d74007bf4