### PR TITLE
fix: use auth metadata when profile missing

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -183,7 +183,17 @@ export const authService = {
 
       if (error) {
         console.error('Profile fetch error:', error);
-        return null;
+        const metadata = user.user_metadata || {};
+        return {
+          id: user.id,
+          email: user.email || '',
+          firstName: metadata.first_name || '',
+          lastName: metadata.last_name || '',
+          middleName: metadata.middle_name,
+          role: metadata.role || 'viewer',
+          createdAt: user.created_at,
+          updatedAt: user.updated_at || user.created_at,
+        };
       }
 
       // Парсим full_name обратно в компоненты для совместимости


### PR DESCRIPTION
## Summary
- return user info from Supabase auth metadata when profile query fails

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68912d08b8ec832e8698bf4c0c9af305