### PR TITLE
fix: navigate to BOQ after Excel upload

### DIFF
--- a/src/pages/TendersPage.tsx
+++ b/src/pages/TendersPage.tsx
@@ -277,7 +277,7 @@ const TendersPage: React.FC = () => {
   }, [loadTenders]);
 
   const handleViewTender = useCallback((tender: TenderWithSummary) => {
-    navigate(`/tenders/${tender.id}`);
+    navigate(`/tender/${tender.id}/boq`);
   }, [navigate]);
 
   const handleEditClick = useCallback((tender: TenderWithSummary) => {
@@ -463,6 +463,7 @@ const TendersPage: React.FC = () => {
             } else {
               message.success('Файл загружен');
               onSuccess?.(result, new XMLHttpRequest());
+              navigate(`/tender/${record.id}/boq`);
             }
           }
         };


### PR DESCRIPTION
## Summary
- redirect to tender BOQ page when opening a tender or after uploading client WBS

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm run type-check` *(fails: Missing script "type-check")*


------
https://chatgpt.com/codex/tasks/task_e_68922025c370832e849d4ecdca5f8256