### PR TITLE
Добавить загрузку Excel на странице тендеров

### DIFF
--- a/src/pages/TendersPage/index.tsx
+++ b/src/pages/TendersPage/index.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
-import { Typography, Button } from 'antd';
-import { PlusOutlined, FolderOpenOutlined } from '@ant-design/icons';
+import React, { useState, useCallback } from 'react';
+import { Typography, Button, Upload, Table, Space, message, Card } from 'antd';
+import { PlusOutlined, FolderOpenOutlined, UploadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import * as XLSX from 'xlsx';
 
 // Components
 import {
@@ -14,11 +16,65 @@ import {
 
 // Hooks
 import { useTenderFilters, useTenders, useTenderActions } from './hooks';
+import type { TenderExcelItem, TenderWithSummary } from './types';
 
 const { Title, Text } = Typography;
 
 const TendersPage: React.FC = () => {
   console.log('🚀 TendersPage component rendered');
+
+  const [excelItems, setExcelItems] = useState<TenderExcelItem[]>([]);
+
+  const excelColumns: ColumnsType<TenderExcelItem> = [
+    { title: '№', dataIndex: 'number', key: 'number', width: 80 },
+    { title: 'Наименование', dataIndex: 'name', key: 'name' },
+    { title: 'Ед. изм.', dataIndex: 'unit', key: 'unit', width: 100 },
+    { title: 'Количество', dataIndex: 'quantity', key: 'quantity', width: 120 },
+    { title: 'Примечание', dataIndex: 'note', key: 'note' }
+  ];
+
+  const handleExcelFile = useCallback(async (file: File) => {
+    console.log('📥 handleExcelFile called with:', {
+      name: file.name,
+      size: file.size,
+      type: file.type
+    });
+
+    const startTime = performance.now();
+    console.log('⏱️ Starting Excel parsing...');
+
+    try {
+      const data = await file.arrayBuffer();
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows = XLSX.utils.sheet_to_json<(string | number | undefined)[]>(sheet, { header: 1 });
+      console.log('📄 Total rows read:', rows.length);
+
+      const items = rows
+        .filter(row => row[2])
+        .map(row => ({
+          number: String(row[0] ?? ''),
+          name: String(row[1] ?? ''),
+          unit: String(row[2] ?? ''),
+          quantity: String(row[3] ?? ''),
+          note: String(row[4] ?? '')
+        }));
+
+      setExcelItems(prev => {
+        console.log('🔄 Excel items state updated:', {
+          oldCount: prev.length,
+          newCount: items.length
+        });
+        return items;
+      });
+
+      const endTime = performance.now();
+      console.log('⏱️ Excel parsing completed in:', `${endTime - startTime}ms`);
+    } catch (error) {
+      console.error('💥 Error parsing Excel file:', error);
+      message.error('Ошибка при чтении файла');
+    }
+  }, []);
 
   // Initialize filters hook with callback to reset pagination
   const resetPaginationCallback = () => {
@@ -90,7 +146,7 @@ const TendersPage: React.FC = () => {
   };
 
   // Handle edit tender action from table
-  const handleEditTenderFromTable = (tender: any) => {
+  const handleEditTenderFromTable = (tender: TenderWithSummary) => {
     console.log('✏️ Edit tender requested from table:', tender.id);
     showEditModal(tender);
   };
@@ -117,14 +173,41 @@ const TendersPage: React.FC = () => {
                 Создавайте, управляйте и отслеживайте тендерные проекты
               </Text>
             </div>
-            <Button
-              type="primary"
-              size="large"
-              icon={<PlusOutlined />}
-              onClick={showCreateModal}
-            >
-              Новый тендер
-            </Button>
+            <Space>
+              <Upload
+                showUploadList={false}
+                accept=".xlsx,.xls"
+                beforeUpload={(file) => {
+                  console.log('📄 File chosen for Excel parsing:', {
+                    name: file.name,
+                    size: file.size
+                  });
+                  handleExcelFile(file);
+                  return false;
+                }}
+              >
+                <Button
+                  size="large"
+                  icon={<UploadOutlined />}
+                  onClick={() => {
+                    console.log('🖱️ Excel upload button clicked');
+                  }}
+                >
+                  Загрузить
+                </Button>
+              </Upload>
+              <Button
+                type="primary"
+                size="large"
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  console.log('🖱️ Create tender button clicked');
+                  showCreateModal();
+                }}
+              >
+                Новый тендер
+              </Button>
+            </Space>
           </div>
 
           {/* Statistics */}
@@ -154,6 +237,17 @@ const TendersPage: React.FC = () => {
           onDeleteTender={handleDeleteTenderFromTable}
           onExcelUpload={handleExcelUpload}
         />
+
+        {excelItems.length > 0 && (
+          <Card title="Импортированные позиции" className="mt-8">
+            <Table
+              dataSource={excelItems}
+              columns={excelColumns}
+              rowKey={(record) => record.number}
+              pagination={false}
+            />
+          </Card>
+        )}
 
         {/* Modals */}
         <CreateTenderModal

--- a/src/pages/TendersPage/types.ts
+++ b/src/pages/TendersPage/types.ts
@@ -99,6 +99,15 @@ export interface ExcelUploadProps {
   onUpload: (file: File) => Promise<void>;
 }
 
+// Excel tender item interface
+export interface TenderExcelItem {
+  number: string;
+  name: string;
+  unit: string;
+  quantity: string;
+  note: string;
+}
+
 // Re-export commonly used types
 export type {
   TenderWithSummary,


### PR DESCRIPTION
## Summary
- добавить кнопку "Загрузить" на странице тендеров
- реализовать парсинг Excel и отображение импортированных позиций

## Testing
- `npm run lint` *(fails: 98 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6893371c2428832e95e98c6d988f8e64