### PR TITLE
Добавить загрузку Excel на странице тендеров и вывод позиций на BOQ

### DIFF
--- a/src/pages/BOQPage.tsx
+++ b/src/pages/BOQPage.tsx
@@ -1,16 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { 
-  Card, 
-  Button, 
-  Typography, 
-  Space, 
+import {
+  Card,
+  Button,
+  Typography,
+  Space,
   Select,
-  Spin,
   message,
-  Empty
+  Empty,
+  List
 } from 'antd';
-import { 
-  PlusOutlined, 
+import {
   FileTextOutlined,
   ReloadOutlined,
   FolderOpenOutlined
@@ -19,6 +18,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import TenderBOQManager from '../components/tender/TenderBOQManager';
 import { tendersApi } from '../lib/supabase/api';
 import type { Tender } from '../lib/supabase/types';
+import type { TenderExcelItem } from './TendersPage/types';
 
 const { Title, Text } = Typography;
 const { Option } = Select;
@@ -32,6 +32,7 @@ const BOQPage: React.FC = () => {
   const [selectedTenderId, setSelectedTenderId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [tendersLoading, setTendersLoading] = useState(false);
+  const [excelItems, setExcelItems] = useState<TenderExcelItem[]>([]);
 
   // Load all tenders for selection
   const loadTenders = useCallback(async () => {
@@ -70,6 +71,28 @@ const BOQPage: React.FC = () => {
   useEffect(() => {
     loadTenders();
   }, [loadTenders]);
+
+  useEffect(() => {
+    console.log('📥 Loading Excel items from localStorage');
+    try {
+      const stored = localStorage.getItem('excelItems');
+      if (stored) {
+        const parsed = JSON.parse(stored) as TenderExcelItem[];
+        console.log('✅ Excel items loaded:', parsed.length);
+        setExcelItems(prev => {
+          console.log('🔄 Excel items state updated:', {
+            oldCount: prev.length,
+            newCount: parsed.length
+          });
+          return parsed;
+        });
+      } else {
+        console.log('ℹ️ No Excel items found in storage');
+      }
+    } catch (error) {
+      console.error('💥 Error reading Excel items from storage:', error);
+    }
+  }, []);
 
   const handleTenderChange = useCallback((tenderId: string) => {
     console.log('🔄 Tender selection changed:', tenderId);
@@ -160,8 +183,8 @@ const BOQPage: React.FC = () => {
       {/* Main Content */}
       <div className="p-6 max-w-none">
         {selectedTenderId ? (
-          <TenderBOQManager 
-            tenderId={selectedTenderId} 
+          <TenderBOQManager
+            tenderId={selectedTenderId}
             key={selectedTenderId} // Force remount when tender changes
           />
         ) : (
@@ -175,6 +198,23 @@ const BOQPage: React.FC = () => {
                   </Text>
                 </div>
               }
+            />
+          </Card>
+        )}
+
+        {excelItems.length > 0 && (
+          <Card title="Импортированные наименования" className="mt-6">
+            <List
+              dataSource={excelItems}
+              renderItem={(item) => (
+                <List.Item>
+                  <span
+                    style={{ paddingLeft: `${(item.number.split('.').length - 1) * 16}px` }}
+                  >
+                    {item.number} {item.name}
+                  </span>
+                </List.Item>
+              )}
             />
           </Card>
         )}

--- a/src/pages/TendersPage/index.tsx
+++ b/src/pages/TendersPage/index.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import { Typography, Button } from 'antd';
-import { PlusOutlined, FolderOpenOutlined } from '@ant-design/icons';
+import React, { useState, useCallback } from 'react';
+import { Typography, Button, Upload, Table, Space, message, Card } from 'antd';
+import { PlusOutlined, FolderOpenOutlined, UploadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import * as XLSX from 'xlsx';
+import { useNavigate } from 'react-router-dom';
 
 // Components
 import {
@@ -14,11 +17,86 @@ import {
 
 // Hooks
 import { useTenderFilters, useTenders, useTenderActions } from './hooks';
+import type { TenderExcelItem, TenderWithSummary } from './types';
 
 const { Title, Text } = Typography;
 
 const TendersPage: React.FC = () => {
   console.log('🚀 TendersPage component rendered');
+
+  const navigate = useNavigate();
+  const [excelItems, setExcelItems] = useState<TenderExcelItem[]>([]);
+
+  const excelColumns: ColumnsType<TenderExcelItem> = [
+    { title: '№', dataIndex: 'number', key: 'number', width: 80 },
+    {
+      title: 'Наименование',
+      dataIndex: 'name',
+      key: 'name',
+      render: (text: string, record: TenderExcelItem) => (
+        <span style={{ paddingLeft: `${(record.number.split('.').length - 1) * 16}px` }}>
+          {text}
+        </span>
+      )
+    },
+    { title: 'Ед. изм.', dataIndex: 'unit', key: 'unit', width: 100 },
+    { title: 'Количество', dataIndex: 'quantity', key: 'quantity', width: 120 },
+    { title: 'Примечание', dataIndex: 'note', key: 'note' }
+  ];
+
+  const handleExcelFile = useCallback(async (file: File) => {
+    console.log('📥 handleExcelFile called with:', {
+      name: file.name,
+      size: file.size,
+      type: file.type
+    });
+
+    const startTime = performance.now();
+    console.log('⏱️ Starting Excel parsing...');
+
+    try {
+      const data = await file.arrayBuffer();
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows = XLSX.utils.sheet_to_json<(string | number | undefined)[]>(sheet, { header: 1 });
+      console.log('📄 Total rows read:', rows.length);
+
+      const items = rows
+        .filter(row => row[2])
+        .map(row => ({
+          number: String(row[0] ?? ''),
+          name: String(row[1] ?? ''),
+          unit: String(row[2] ?? ''),
+          quantity: String(row[3] ?? ''),
+          note: String(row[4] ?? '')
+        }));
+
+      setExcelItems(prev => {
+        console.log('🔄 Excel items state updated:', {
+          oldCount: prev.length,
+          newCount: items.length
+        });
+        return items;
+      });
+
+      try {
+        console.log('💾 Saving Excel items to localStorage...');
+        localStorage.setItem('excelItems', JSON.stringify(items));
+        console.log('✅ Excel items saved to localStorage');
+      } catch (storageError) {
+        console.error('💥 Failed to save Excel items to localStorage:', storageError);
+      }
+
+      const endTime = performance.now();
+      console.log('⏱️ Excel parsing completed in:', `${endTime - startTime}ms`);
+
+      console.log('📨 Navigating to /boq to display imported items');
+      navigate('/boq');
+    } catch (error) {
+      console.error('💥 Error parsing Excel file:', error);
+      message.error('Ошибка при чтении файла');
+    }
+  }, [navigate]);
 
   // Initialize filters hook with callback to reset pagination
   const resetPaginationCallback = () => {
@@ -90,7 +168,7 @@ const TendersPage: React.FC = () => {
   };
 
   // Handle edit tender action from table
-  const handleEditTenderFromTable = (tender: any) => {
+  const handleEditTenderFromTable = (tender: TenderWithSummary) => {
     console.log('✏️ Edit tender requested from table:', tender.id);
     showEditModal(tender);
   };
@@ -117,14 +195,41 @@ const TendersPage: React.FC = () => {
                 Создавайте, управляйте и отслеживайте тендерные проекты
               </Text>
             </div>
-            <Button
-              type="primary"
-              size="large"
-              icon={<PlusOutlined />}
-              onClick={showCreateModal}
-            >
-              Новый тендер
-            </Button>
+            <Space>
+              <Upload
+                showUploadList={false}
+                accept=".xlsx,.xls"
+                beforeUpload={(file) => {
+                  console.log('📄 File chosen for Excel parsing:', {
+                    name: file.name,
+                    size: file.size
+                  });
+                  handleExcelFile(file);
+                  return false;
+                }}
+              >
+                <Button
+                  size="large"
+                  icon={<UploadOutlined />}
+                  onClick={() => {
+                    console.log('🖱️ Excel upload button clicked');
+                  }}
+                >
+                  Загрузить
+                </Button>
+              </Upload>
+              <Button
+                type="primary"
+                size="large"
+                icon={<PlusOutlined />}
+                onClick={() => {
+                  console.log('🖱️ Create tender button clicked');
+                  showCreateModal();
+                }}
+              >
+                Новый тендер
+              </Button>
+            </Space>
           </div>
 
           {/* Statistics */}
@@ -154,6 +259,17 @@ const TendersPage: React.FC = () => {
           onDeleteTender={handleDeleteTenderFromTable}
           onExcelUpload={handleExcelUpload}
         />
+
+        {excelItems.length > 0 && (
+          <Card title="Импортированные позиции" className="mt-8">
+            <Table
+              dataSource={excelItems}
+              columns={excelColumns}
+              rowKey={(record) => record.number}
+              pagination={false}
+            />
+          </Card>
+        )}
 
         {/* Modals */}
         <CreateTenderModal

--- a/src/pages/TendersPage/types.ts
+++ b/src/pages/TendersPage/types.ts
@@ -99,6 +99,15 @@ export interface ExcelUploadProps {
   onUpload: (file: File) => Promise<void>;
 }
 
+// Excel tender item interface
+export interface TenderExcelItem {
+  number: string;
+  name: string;
+  unit: string;
+  quantity: string;
+  note: string;
+}
+
 // Re-export commonly used types
 export type {
   TenderWithSummary,


### PR DESCRIPTION
## Summary
- добавить кнопку "Загрузить" на странице тендеров
- реализовать парсинг Excel и отображение импортированных позиций
- сохранять импортированные строки и выводить их на странице BOQ
- отображать наименования и иерархию из Excel в портале

## Testing
- `npm run lint` *(fails: 93 errors, 3 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6893371c2428832e95e98c6d988f8e64