### PR TITLE
feat: allow manual volume input for client positions

### DIFF
--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -109,7 +109,8 @@ export type DatabaseTables = {
       created_at: string;
       updated_at: string;
       unit: string | null;       // Ед. изм. из Excel
-      volume: number | null;     // Объем работ из Excel  
+      volume: number | null;     // Объем работ из Excel
+      manual_volume: number | null; // Объем, заданный вручную
       client_note: string | null; // Примечание из Excel
     };
     Insert: {
@@ -122,6 +123,7 @@ export type DatabaseTables = {
       total_works_cost?: number;
       unit?: string | null;      // Ед. изм. из Excel
       volume?: number | null;    // Объем работ из Excel
+      manual_volume?: number | null; // Объем, заданный вручную
       client_note?: string | null; // Примечание из Excel
       created_at?: string;
       updated_at?: string;
@@ -136,6 +138,7 @@ export type DatabaseTables = {
       total_works_cost?: number;
       unit?: string | null;      // Ед. изм. из Excel
       volume?: number | null;    // Объем работ из Excel
+      manual_volume?: number | null; // Объем, заданный вручную
       client_note?: string | null; // Примечание из Excel
       created_at?: string;
       updated_at?: string;

--- a/supabase/migrations/20250210120000_add_manual_volume_to_client_positions.sql
+++ b/supabase/migrations/20250210120000_add_manual_volume_to_client_positions.sql
@@ -1,0 +1,5 @@
+-- Добавляет поле manual_volume для ручного ввода объема работ
+ALTER TABLE public.client_positions
+  ADD COLUMN IF NOT EXISTS manual_volume numeric(12,4);
+
+COMMENT ON COLUMN public.client_positions.manual_volume IS 'Объем работ, заданный вручную';

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -170,6 +170,7 @@ CREATE TABLE IF NOT EXISTS "public"."client_positions" (
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "unit" "text",
     "volume" numeric(12,4),
+    "manual_volume" numeric(12,4),
     "client_note" "text",
     "item_no" character varying(10) NOT NULL,
     "work_name" "text" NOT NULL,
@@ -193,6 +194,8 @@ COMMENT ON COLUMN "public"."client_positions"."unit" IS 'Единица изме
 
 
 COMMENT ON COLUMN "public"."client_positions"."volume" IS 'Объем работ из Excel';
+
+COMMENT ON COLUMN "public"."client_positions"."manual_volume" IS 'Объем работ, заданный вручную';
 
 
 


### PR DESCRIPTION
## Summary
- add manual_volume field to client_positions types
- allow editing manual volume in BOQ manager

## Testing
- `npm run lint` (fails: Unexpected any, no-unused-vars, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68944c29ad84832e9a8476cf5ec7a1f7