### PR TITLE
feat: allow manual volume input for client positions

### DIFF
--- a/src/components/tender/TenderBOQManagerNew.tsx
+++ b/src/components/tender/TenderBOQManagerNew.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { PlusOutlined, EditOutlined, CalculatorOutlined, CloseOutlined } from '@ant-design/icons';
-import { message, Spin } from 'antd';
+import { message, Spin, InputNumber } from 'antd';
 import { clientPositionsApi, boqItemsApi, materialsApi, worksApi } from '../../lib/supabase/api';
 import AutoCompleteSearch from '../common/AutoCompleteSearch';
 import { formatCurrency, formatQuantity, formatUnitRate } from '../../utils/formatters';
@@ -155,6 +155,46 @@ const TenderBOQManagerNew: React.FC<TenderBOQManagerNewProps> = ({ tenderId }) =
       selectedItemId: prev.name !== value ? null : prev.selectedItemId
     }));
   }, []);
+
+  // Handle manual volume changes
+  const handleManualVolumeChange = useCallback(
+    (positionId: string, value: number | null) => {
+      console.log('✏️ handleManualVolumeChange called:', { positionId, value });
+
+      const oldValue = positions.find((p) => p.id === positionId)?.manual_volume ?? null;
+      console.log('🔁 manual volume state change:', {
+        positionId,
+        oldValue,
+        newValue: value,
+      });
+      setPositions((prev) =>
+        prev.map((p) => (p.id === positionId ? { ...p, manual_volume: value } : p))
+      );
+
+      clientPositionsApi
+        .update(positionId, { manual_volume: value })
+        .then((result) => {
+          console.log('📦 manual volume update result:', result);
+          if (result.error) {
+            console.error('❌ manual volume update failed:', result.error);
+            message.error('Ошибка сохранения объема');
+            setPositions((prev) =>
+              prev.map((p) => (p.id === positionId ? { ...p, manual_volume: oldValue } : p))
+            );
+          } else {
+            console.log('✅ manual volume updated successfully');
+          }
+        })
+        .catch((error) => {
+          console.error('💥 manual volume update exception:', error);
+          message.error('Ошибка сохранения объема');
+          setPositions((prev) =>
+            prev.map((p) => (p.id === positionId ? { ...p, manual_volume: oldValue } : p))
+          );
+        });
+    },
+    [positions]
+  );
 
   // Add new BOQ item
   const addItem = useCallback(async () => {
@@ -365,10 +405,43 @@ const TenderBOQManagerNew: React.FC<TenderBOQManagerNewProps> = ({ tenderId }) =
                         <h3 className="text-sm font-semibold text-gray-900">
                           {position.item_no}. {position.work_name}
                         </h3>
-                        {position.unit && position.volume && (
-                          <span className="text-xs text-gray-500">
-                            ({formatQuantity(position.volume)} {position.unit})
-                          </span>
+                        {position.unit && (
+                          <>
+                            <span
+                              className="text-xs text-gray-500"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                console.log('🖱️ Original volume display clicked for position:', position.id);
+                              }}
+                            >
+                              ({formatQuantity(position.volume ?? 0)} {position.unit})
+                            </span>
+                            <div className="flex items-center gap-1">
+                              <InputNumber
+                                size="small"
+                                min={0}
+                                value={position.manual_volume ?? undefined}
+                                placeholder="Ручной объём"
+                                className="w-20"
+                                onChange={(value) =>
+                                  handleManualVolumeChange(position.id, value as number | null)
+                                }
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  console.log('🖱️ Manual volume input clicked for position:', position.id);
+                                }}
+                              />
+                              <span
+                                className="text-xs text-gray-500"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  console.log('🖱️ Manual volume unit clicked for position:', position.id);
+                                }}
+                              >
+                                {position.unit}
+                              </span>
+                            </div>
+                          </>
                         )}
                       </div>
                       {position.client_note && (

--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -109,7 +109,8 @@ export type DatabaseTables = {
       created_at: string;
       updated_at: string;
       unit: string | null;       // Ед. изм. из Excel
-      volume: number | null;     // Объем работ из Excel  
+      volume: number | null;     // Объем работ из Excel
+      manual_volume: number | null; // Объем, заданный вручную
       client_note: string | null; // Примечание из Excel
     };
     Insert: {
@@ -122,6 +123,7 @@ export type DatabaseTables = {
       total_works_cost?: number;
       unit?: string | null;      // Ед. изм. из Excel
       volume?: number | null;    // Объем работ из Excel
+      manual_volume?: number | null; // Объем, заданный вручную
       client_note?: string | null; // Примечание из Excel
       created_at?: string;
       updated_at?: string;
@@ -136,6 +138,7 @@ export type DatabaseTables = {
       total_works_cost?: number;
       unit?: string | null;      // Ед. изм. из Excel
       volume?: number | null;    // Объем работ из Excel
+      manual_volume?: number | null; // Объем, заданный вручную
       client_note?: string | null; // Примечание из Excel
       created_at?: string;
       updated_at?: string;

--- a/supabase/migrations/20250210120000_add_manual_volume_to_client_positions.sql
+++ b/supabase/migrations/20250210120000_add_manual_volume_to_client_positions.sql
@@ -1,0 +1,5 @@
+-- Добавляет поле manual_volume для ручного ввода объема работ
+ALTER TABLE public.client_positions
+  ADD COLUMN IF NOT EXISTS manual_volume numeric(12,4);
+
+COMMENT ON COLUMN public.client_positions.manual_volume IS 'Объем работ, заданный вручную';

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -170,6 +170,7 @@ CREATE TABLE IF NOT EXISTS "public"."client_positions" (
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "unit" "text",
     "volume" numeric(12,4),
+    "manual_volume" numeric(12,4),
     "client_note" "text",
     "item_no" character varying(10) NOT NULL,
     "work_name" "text" NOT NULL,
@@ -193,6 +194,8 @@ COMMENT ON COLUMN "public"."client_positions"."unit" IS 'Единица изме
 
 
 COMMENT ON COLUMN "public"."client_positions"."volume" IS 'Объем работ из Excel';
+
+COMMENT ON COLUMN "public"."client_positions"."manual_volume" IS 'Объем работ, заданный вручную';
 
 
 


### PR DESCRIPTION
## Summary
- add manual_volume field to client_positions types
- allow editing manual volume in BOQ manager
- keep client volume display and add separate manual volume input
- show client unit next to manual volume input

## Testing
- `npm run lint` (fails: Unexpected any, no-unused-vars, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68944c29ad84832e9a8476cf5ec7a1f7