### PR TITLE
feat: add material coefficients

### DIFF
--- a/src/components/tender/BOQItemForm.tsx
+++ b/src/components/tender/BOQItemForm.tsx
@@ -34,6 +34,8 @@ interface FormData {
   unit: string;
   quantity: number;
   unit_rate: number;
+  conversion_coefficient?: number;
+  consumption_coefficient?: number;
   material_id?: string;
   work_id?: string;
   category?: string;
@@ -75,6 +77,8 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
         unit: editingItem.unit,
         quantity: editingItem.quantity,
         unit_rate: editingItem.unit_rate,
+        conversion_coefficient: editingItem.conversion_coefficient ?? 1,
+        consumption_coefficient: editingItem.consumption_coefficient ?? 1,
         material_id: editingItem.material_id || undefined,
         work_id: editingItem.work_id || undefined,
         category: editingItem.category || '',
@@ -84,7 +88,12 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
       });
     } else if (visible) {
       form.resetFields();
-      form.setFieldsValue({ item_type: 'material', sort_order: 0 });
+      form.setFieldsValue({
+        item_type: 'material',
+        sort_order: 0,
+        conversion_coefficient: 1,
+        consumption_coefficient: 1
+      });
     }
   }, [visible, editingItem, form]);
 
@@ -109,13 +118,19 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
 
   const handleLibraryItemSelect = (_value: string, option: any) => {
     const selectedItem = option.item;
-    
+    console.log('🖱️ Library item selected:', {
+      id: selectedItem.id,
+      name: selectedItem.name,
+    });
+
     // Auto-fill form fields
     form.setFieldsValue({
       description: selectedItem.name,
       unit: selectedItem.unit,
       unit_rate: selectedItem.base_price,
-      category: selectedItem.category || ''
+      category: selectedItem.category || '',
+      conversion_coefficient: selectedItem.conversion_coefficient ?? 1,
+      consumption_coefficient: selectedItem.consumption_coefficient ?? 1,
     });
   };
 
@@ -129,6 +144,7 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
   };
 
   const handleSubmit = async (values: FormData) => {
+    console.log('🚀 BOQItemForm.handleSubmit called with:', values);
     setLoading(true);
 
     try {
@@ -166,6 +182,7 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
   };
 
   const handleCancel = () => {
+    console.log('🛑 BOQItemForm.cancel');
     form.resetFields();
     onCancel();
   };
@@ -312,6 +329,39 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
             </Form.Item>
           </Col>
         </Row>
+
+        {itemType === 'material' && (
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item
+                name="conversion_coefficient"
+                label="Коэффициент перевода"
+                rules={[{ required: true, message: 'Введите коэффициент перевода' }]}
+              >
+                <InputNumber
+                  min={0}
+                  precision={4}
+                  placeholder="1.0000"
+                  className="w-full"
+                />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item
+                name="consumption_coefficient"
+                label="Коэффициент расхода"
+                rules={[{ required: true, message: 'Введите коэффициент расхода' }]}
+              >
+                <InputNumber
+                  min={0}
+                  precision={4}
+                  placeholder="1.0000"
+                  className="w-full"
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        )}
 
         <Row gutter={16}>
           <Col span={12}>

--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -19,6 +19,8 @@ export type DatabaseTables = {
       unit: string;
       quantity: number;
       unit_rate: number;
+      conversion_coefficient: number | null;
+      consumption_coefficient: number | null;
       total_amount: number;
       material_id: string | null;
       work_id: string | null;
@@ -38,6 +40,8 @@ export type DatabaseTables = {
       unit: string;
       quantity: number;
       unit_rate: number;
+      conversion_coefficient?: number | null;
+      consumption_coefficient?: number | null;
       material_id?: string | null;
       work_id?: string | null;
       imported_at?: string | null;
@@ -60,6 +64,8 @@ export type DatabaseTables = {
       unit?: string;
       quantity?: number;
       unit_rate?: number;
+      conversion_coefficient?: number | null;
+      consumption_coefficient?: number | null;
       material_id?: string | null;
       work_id?: string | null;
       imported_at?: string | null;


### PR DESCRIPTION
## Summary
- rename translation coefficient field to conversion coefficient in BOQ item types
- capture conversion and consumption coefficients when adding materials via modal or inline forms

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 137 problems, 134 errors, 3 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689460022608832ebf7d1645c7fe4b62