### PR TITLE
feat: add material coefficient fields

### DIFF
--- a/src/components/tender/BOQItemForm.tsx
+++ b/src/components/tender/BOQItemForm.tsx
@@ -40,6 +40,8 @@ interface FormData {
   subcategory?: string;
   notes?: string;
   sort_order?: number;
+  consumption_coefficient?: number;
+  conversion_coefficient?: number;
 }
 
 const BOQItemForm: React.FC<BOQItemFormProps> = ({
@@ -80,11 +82,18 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
         category: editingItem.category || '',
         subcategory: editingItem.subcategory || '',
         notes: editingItem.notes || '',
-        sort_order: editingItem.sort_order || 0
+        sort_order: editingItem.sort_order || 0,
+        consumption_coefficient: editingItem.consumption_coefficient || 1,
+        conversion_coefficient: editingItem.conversion_coefficient || 1
       });
     } else if (visible) {
       form.resetFields();
-      form.setFieldsValue({ item_type: 'material', sort_order: 0 });
+      form.setFieldsValue({
+        item_type: 'material',
+        sort_order: 0,
+        consumption_coefficient: 1,
+        conversion_coefficient: 1,
+      });
     }
   }, [visible, editingItem, form]);
 
@@ -129,6 +138,7 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
   };
 
   const handleSubmit = async (values: FormData) => {
+    console.log('🚀 BOQItemForm handleSubmit called with:', values);
     setLoading(true);
 
     try {
@@ -137,8 +147,14 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
         tender_id: tenderId,
         client_position_id: positionId,
         material_id: values.item_type === 'material' ? values.material_id : null,
-        work_id: values.item_type === 'work' ? values.work_id : null
+        work_id: values.item_type === 'work' ? values.work_id : null,
+        consumption_coefficient:
+          values.item_type === 'material' ? values.consumption_coefficient : undefined,
+        conversion_coefficient:
+          values.item_type === 'material' ? values.conversion_coefficient : undefined,
       };
+
+      console.log('📡 Sending BOQ item data:', itemData);
 
       if (isEditing && editingItem) {
         const result = await boqItemsApi.update(editingItem.id, itemData);
@@ -312,6 +328,46 @@ const BOQItemForm: React.FC<BOQItemFormProps> = ({
             </Form.Item>
           </Col>
         </Row>
+
+        {itemType === 'material' && (
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item
+                name="consumption_coefficient"
+                label="Коэф. расхода"
+                rules={[{ required: true, message: 'Введите коэффициент расхода' }]}
+              >
+                <InputNumber
+                  min={0.0001}
+                  precision={4}
+                  placeholder="1.0000"
+                  className="w-full"
+                  onChange={(value) =>
+                    console.log('✏️ Consumption coefficient changed:', value)
+                  }
+                />
+              </Form.Item>
+            </Col>
+
+            <Col span={12}>
+              <Form.Item
+                name="conversion_coefficient"
+                label="Коэф. перевода"
+                rules={[{ required: true, message: 'Введите коэффициент перевода' }]}
+              >
+                <InputNumber
+                  min={0.0001}
+                  precision={4}
+                  placeholder="1.0000"
+                  className="w-full"
+                  onChange={(value) =>
+                    console.log('✏️ Conversion coefficient changed:', value)
+                  }
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        )}
 
         <Row gutter={16}>
           <Col span={12}>

--- a/src/components/tender/ClientPositionCard.tsx
+++ b/src/components/tender/ClientPositionCard.tsx
@@ -166,8 +166,20 @@ const ClientPositionCard: React.FC<ClientPositionCardProps> = ({
     }
   }, []);
 
-  const handleQuickAdd = useCallback(async (item: Material | WorkItem, type: 'material' | 'work', quantity: number) => {
-    console.log('🚀 Quick add item:', { item: item.name, type, quantity });
+  const handleQuickAdd = useCallback(async (
+    item: Material | WorkItem,
+    type: 'material' | 'work',
+    quantity: number,
+    consumptionCoefficient = 1,
+    conversionCoefficient = 1
+  ) => {
+    console.log('🚀 Quick add item:', {
+      item: item.name,
+      type,
+      quantity,
+      consumptionCoefficient,
+      conversionCoefficient
+    });
     
     try {
       // Calculate next item number
@@ -188,7 +200,9 @@ const ClientPositionCard: React.FC<ClientPositionCardProps> = ({
         quantity: quantity,
         unit_rate: 0, // Will be set manually by user
         material_id: type === 'material' ? item.id : null,
-        work_id: type === 'work' ? item.id : null
+        work_id: type === 'work' ? item.id : null,
+        consumption_coefficient: type === 'material' ? consumptionCoefficient : undefined,
+        conversion_coefficient: type === 'material' ? conversionCoefficient : undefined
       };
 
       console.log('📡 Creating new BOQ item:', newItemData);

--- a/src/components/tender/ExpandableSearchBar.tsx
+++ b/src/components/tender/ExpandableSearchBar.tsx
@@ -24,7 +24,13 @@ const { Text } = Typography;
 const { Option } = Select;
 
 export interface ExpandableSearchBarProps {
-  onAddItem: (item: Material | WorkItem, type: 'material' | 'work', quantity: number) => void;
+  onAddItem: (
+    item: Material | WorkItem,
+    type: 'material' | 'work',
+    quantity: number,
+    consumptionCoefficient?: number,
+    conversionCoefficient?: number
+  ) => void;
   onClose?: () => void;
   placeholder?: string;
 }
@@ -52,6 +58,8 @@ const ExpandableSearchBar: React.FC<ExpandableSearchBarProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [works, setWorks] = useState<WorkItem[]>([]);
+  const [consumptionCoefficient, setConsumptionCoefficient] = useState(1);
+  const [conversionCoefficient, setConversionCoefficient] = useState(1);
 
   // Load data on mount
   useEffect(() => {
@@ -163,6 +171,9 @@ const ExpandableSearchBar: React.FC<ExpandableSearchBarProps> = ({
       type: selectedOption.type
     });
 
+    setConsumptionCoefficient(1);
+    setConversionCoefficient(1);
+
     // Clear search
     setSearchValue('');
     setSearchOptions([]);
@@ -183,15 +194,25 @@ const ExpandableSearchBar: React.FC<ExpandableSearchBarProps> = ({
     console.log('➕ Adding item:', {
       item: selectedItem.item.name,
       type: selectedItem.type,
-      quantity
+      quantity,
+      consumptionCoefficient,
+      conversionCoefficient
     });
 
-    onAddItem(selectedItem.item, selectedItem.type, quantity);
+    onAddItem(
+      selectedItem.item,
+      selectedItem.type,
+      quantity,
+      consumptionCoefficient,
+      conversionCoefficient
+    );
     
     // Reset form
     setSelectedItem(null);
     setQuantity(1);
     setSearchValue('');
+    setConsumptionCoefficient(1);
+    setConversionCoefficient(1);
     
     if (onClose) {
       onClose();
@@ -289,18 +310,53 @@ const ExpandableSearchBar: React.FC<ExpandableSearchBarProps> = ({
         )}
 
         {/* Quantity and Add Button */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <Text className="whitespace-nowrap">Количество:</Text>
           <InputNumber
             value={quantity}
-            onChange={(value) => setQuantity(value || 1)}
+            onChange={(value) => {
+              console.log('✏️ Quantity changed:', value);
+              setQuantity(value || 1);
+            }}
             min={0.01}
             step={0.01}
             placeholder="Кол-во"
             style={{ width: 100 }}
             size="middle"
           />
-          
+
+          {selectedItem?.type === 'material' && (
+            <>
+              <Text className="whitespace-nowrap">Коэф. расхода:</Text>
+              <InputNumber
+                value={consumptionCoefficient}
+                onChange={(value) => {
+                  console.log('✏️ Consumption coefficient changed:', value);
+                  setConsumptionCoefficient(value || 1);
+                }}
+                min={0.0001}
+                step={0.0001}
+                placeholder="Расход"
+                style={{ width: 100 }}
+                size="middle"
+              />
+
+              <Text className="whitespace-nowrap">Коэф. перевода:</Text>
+              <InputNumber
+                value={conversionCoefficient}
+                onChange={(value) => {
+                  console.log('✏️ Conversion coefficient changed:', value);
+                  setConversionCoefficient(value || 1);
+                }}
+                min={0.0001}
+                step={0.0001}
+                placeholder="Перевод"
+                style={{ width: 100 }}
+                size="middle"
+              />
+            </>
+          )}
+
           <Button
             type="primary"
             icon={<PlusOutlined />}

--- a/src/components/tender/InlineBoqItemForm.tsx
+++ b/src/components/tender/InlineBoqItemForm.tsx
@@ -22,6 +22,8 @@ interface FormValues {
   unit_rate: number;
   material_id?: string;
   work_id?: string;
+  consumption_coefficient: number;
+  conversion_coefficient: number;
 }
 
 interface LibraryOption {
@@ -44,6 +46,16 @@ const schema = yup.object({
     .typeError('Введите цену')
     .min(0, 'Цена не может быть отрицательной')
     .required('Введите цену'),
+  consumption_coefficient: yup
+    .number()
+    .typeError('Введите коэффициент расхода')
+    .moreThan(0, 'Коэффициент должен быть больше 0')
+    .required('Введите коэффициент расхода'),
+  conversion_coefficient: yup
+    .number()
+    .typeError('Введите коэффициент перевода')
+    .moreThan(0, 'Коэффициент должен быть больше 0')
+    .required('Введите коэффициент перевода'),
 });
 
 const InlineBoqItemForm: React.FC<InlineBoqItemFormProps> = ({
@@ -68,6 +80,8 @@ const InlineBoqItemForm: React.FC<InlineBoqItemFormProps> = ({
       unit: '',
       quantity: 0,
       unit_rate: 0,
+      consumption_coefficient: 1,
+      conversion_coefficient: 1,
     },
     resolver: yupResolver(schema),
   });
@@ -135,6 +149,10 @@ const InlineBoqItemForm: React.FC<InlineBoqItemFormProps> = ({
       client_position_id: positionId,
       material_id: values.item_type === 'material' ? values.material_id : null,
       work_id: values.item_type === 'work' ? values.work_id : null,
+      consumption_coefficient:
+        values.item_type === 'material' ? values.consumption_coefficient : undefined,
+      conversion_coefficient:
+        values.item_type === 'material' ? values.conversion_coefficient : undefined,
     };
     try {
       console.log('📡 Calling boqItemsApi.create', payload);
@@ -244,10 +262,64 @@ const InlineBoqItemForm: React.FC<InlineBoqItemFormProps> = ({
               precision={3}
               placeholder="Кол-во"
               style={{ width: 120 }}
+              onChange={(value) => {
+                console.log('✏️ Quantity changed:', value);
+                field.onChange(value);
+              }}
             />
           )}
         />
       </Form.Item>
+
+      {itemType === 'material' && (
+        <>
+          <Form.Item
+            validateStatus={errors.consumption_coefficient ? 'error' : ''}
+            help={errors.consumption_coefficient?.message}
+          >
+            <Controller
+              name="consumption_coefficient"
+              control={control}
+              render={({ field }) => (
+                <InputNumber
+                  {...field}
+                  min={0.0001}
+                  precision={4}
+                  placeholder="Коэф. расхода"
+                  style={{ width: 130 }}
+                  onChange={(value) => {
+                    console.log('✏️ Consumption coefficient changed:', value);
+                    field.onChange(value);
+                  }}
+                />
+              )}
+            />
+          </Form.Item>
+
+          <Form.Item
+            validateStatus={errors.conversion_coefficient ? 'error' : ''}
+            help={errors.conversion_coefficient?.message}
+          >
+            <Controller
+              name="conversion_coefficient"
+              control={control}
+              render={({ field }) => (
+                <InputNumber
+                  {...field}
+                  min={0.0001}
+                  precision={4}
+                  placeholder="Коэф. перевода"
+                  style={{ width: 130 }}
+                  onChange={(value) => {
+                    console.log('✏️ Conversion coefficient changed:', value);
+                    field.onChange(value);
+                  }}
+                />
+              )}
+            />
+          </Form.Item>
+        </>
+      )}
 
       <Form.Item
         validateStatus={errors.unit_rate ? 'error' : ''}

--- a/src/components/tender/QuickAddSearchBar.tsx
+++ b/src/components/tender/QuickAddSearchBar.tsx
@@ -1,0 +1,1 @@
+export { default } from './ExpandableSearchBar';

--- a/src/components/tender/TenderBOQManager.tsx
+++ b/src/components/tender/TenderBOQManager.tsx
@@ -27,7 +27,7 @@ import {
   Divider,
   Spin
 } from 'antd';
-import ExpandableSearchBar from './ExpandableSearchBar';
+import QuickAddSearchBar from './QuickAddSearchBar';
 import {
   PlusOutlined,
   EditOutlined,
@@ -203,8 +203,23 @@ const TenderBOQManager: React.FC<TenderBOQManagerProps> = ({ tenderId }) => {
     loadPositions();
   };
 
-  const handleQuickAdd = useCallback(async (item: Material | WorkItem, type: 'material' | 'work', quantity: number, positionId: string) => {
-    console.log('🚀 Quick add item to position:', { item: item.name, type, quantity, positionId });
+  const handleQuickAdd = useCallback(
+    async (
+      item: Material | WorkItem,
+      type: 'material' | 'work',
+      quantity: number,
+      consumptionCoefficient: number,
+      conversionCoefficient: number,
+      positionId: string
+    ) => {
+      console.log('🚀 Quick add item to position:', {
+        item: item.name,
+        type,
+        quantity,
+        consumptionCoefficient,
+        conversionCoefficient,
+        positionId
+      });
     
     try {
       // Find position to calculate next item number
@@ -231,7 +246,9 @@ const TenderBOQManager: React.FC<TenderBOQManagerProps> = ({ tenderId }) => {
         quantity: quantity,
         unit_rate: 0, // Will be set manually by user
         material_id: type === 'material' ? item.id : null,
-        work_id: type === 'work' ? item.id : null
+        work_id: type === 'work' ? item.id : null,
+        consumption_coefficient: type === 'material' ? consumptionCoefficient : undefined,
+        conversion_coefficient: type === 'material' ? conversionCoefficient : undefined
       };
 
       console.log('📡 Creating new BOQ item:', newItemData);
@@ -744,8 +761,10 @@ const TenderBOQManager: React.FC<TenderBOQManagerProps> = ({ tenderId }) => {
                   <Text strong className="block mb-3 text-gray-700">
                     Быстрое добавление в позицию {position.position_number}
                   </Text>
-                  <QuickAddSearchBar 
-                    onAddItem={(item, type, quantity) => handleQuickAdd(item, type, quantity, position.id)}
+                  <QuickAddSearchBar
+                    onAddItem={(item, type, quantity, consumption, conversion) =>
+                      handleQuickAdd(item, type, quantity, consumption || 1, conversion || 1, position.id)
+                    }
                     placeholder="Поиск материалов и работ для добавления в позицию..."
                   />
                 </div>

--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -19,6 +19,8 @@ export type DatabaseTables = {
       unit: string;
       quantity: number;
       unit_rate: number;
+      consumption_coefficient: number;
+      conversion_coefficient: number;
       total_amount: number;
       material_id: string | null;
       work_id: string | null;
@@ -38,6 +40,8 @@ export type DatabaseTables = {
       unit: string;
       quantity: number;
       unit_rate: number;
+      consumption_coefficient?: number;
+      conversion_coefficient?: number;
       material_id?: string | null;
       work_id?: string | null;
       imported_at?: string | null;
@@ -60,6 +64,8 @@ export type DatabaseTables = {
       unit?: string;
       quantity?: number;
       unit_rate?: number;
+      consumption_coefficient?: number;
+      conversion_coefficient?: number;
       material_id?: string | null;
       work_id?: string | null;
       imported_at?: string | null;

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -128,6 +128,8 @@ CREATE TABLE IF NOT EXISTS "public"."boq_items" (
     "unit" "text" NOT NULL,
     "quantity" numeric(12,4) NOT NULL,
     "unit_rate" numeric(12,4) NOT NULL,
+    "consumption_coefficient" numeric(12,4) DEFAULT 1 NOT NULL,
+    "conversion_coefficient" numeric(12,4) DEFAULT 1 NOT NULL,
     "total_amount" numeric(15,2) GENERATED ALWAYS AS (("quantity" * "unit_rate")) STORED,
     "material_id" "uuid",
     "work_id" "uuid",
@@ -157,6 +159,10 @@ COMMENT ON COLUMN "public"."boq_items"."sub_number" IS 'Подномер эле�
 
 
 COMMENT ON COLUMN "public"."boq_items"."sort_order" IS 'Порядок сортировки внутри позиции заказчика';
+
+COMMENT ON COLUMN "public"."boq_items"."consumption_coefficient" IS 'Коэффициент расхода материала';
+
+COMMENT ON COLUMN "public"."boq_items"."conversion_coefficient" IS 'Коэффициент перевода единицы измерения материала';
 
 
 


### PR DESCRIPTION
## Summary
- add conversion and consumption coefficient inputs for materials
- persist new coefficients when adding BOQ items
- extend database schema and types for new coefficients

## Testing
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68947745cb0c832eba849c622c439764