### PR TITLE
feat: добавить сервис администрирования затрат на строительство

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const Materials = React.lazy(() => import('./pages/Materials'));
 const Works = React.lazy(() => import('./pages/Works'));
 const UsersPage = React.lazy(() => import('./pages/admin/UsersPage'));
 const SettingsPage = React.lazy(() => import('./pages/admin/SettingsPage'));
+const ConstructionCostsPage = React.lazy(() => import('./pages/admin/ConstructionCostsPage'));
 const ProfilePage = React.lazy(() => import('./pages/ProfilePage'));
 
 function App() {
@@ -84,16 +85,24 @@ function App() {
 
             {/* Admin routes */}
             <Route path="admin">
-              <Route 
-                path="users" 
+              <Route
+                path="users"
                 element={
                   <React.Suspense fallback={<div>Загрузка...</div>}>
                     <UsersPage />
                   </React.Suspense>
                 } 
               />
-              <Route 
-                path="settings" 
+              <Route
+                path="construction-costs"
+                element={
+                  <React.Suspense fallback={<div>Загрузка...</div>}>
+                    <ConstructionCostsPage />
+                  </React.Suspense>
+                }
+              />
+              <Route
+                path="settings"
                 element={
                   <React.Suspense fallback={<div>Загрузка...</div>}>
                     <SettingsPage />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -84,6 +84,12 @@ const AppLayout: React.FC = () => {
           path: '/admin/users',
         },
         {
+          key: 'construction-costs',
+          icon: null,
+          label: <Link to="/admin/construction-costs">Затраты на строительство</Link>,
+          path: '/admin/construction-costs',
+        },
+        {
           key: 'settings',
           icon: null,
           label: <Link to="/admin/settings">Настройки</Link>,
@@ -147,6 +153,8 @@ const AppLayout: React.FC = () => {
           breadcrumbItems.push({ title: <span>Администрирование</span> });
           if (pathSegments[1] === 'users') {
             breadcrumbItems.push({ title: <span>Пользователи</span> });
+          } else if (pathSegments[1] === 'construction-costs') {
+            breadcrumbItems.push({ title: <span>Затраты на строительство</span> });
           } else if (pathSegments[1] === 'settings') {
             breadcrumbItems.push({ title: <span>Настройки</span> });
           }

--- a/src/lib/supabase/api/costs.ts
+++ b/src/lib/supabase/api/costs.ts
@@ -1,0 +1,151 @@
+import { supabase } from '../client';
+import type {
+  CostCategory,
+  CostCategoryInsert,
+  DetailCostCategory,
+  DetailCostCategoryInsert,
+  Location,
+  LocationInsert,
+  ApiResponse,
+  DetailCostWithRelations,
+} from '../types';
+import { handleSupabaseError } from './utils';
+
+// API for construction cost management
+export const costsApi = {
+  // Fetch all detail cost categories with related data
+  async getAll(): Promise<ApiResponse<DetailCostWithRelations[]>> {
+    console.log('🚀 [costsApi.getAll] called');
+    try {
+      const { data, error } = await supabase
+        .from('detail_cost_categories')
+        .select('*, cost_categories(*), location(*)')
+        .order('name');
+
+      if (error) {
+        console.error('❌ [costsApi.getAll] failed:', error);
+        return { error: handleSupabaseError(error, 'Get cost details') };
+      }
+
+      console.log('✅ [costsApi.getAll] completed:', data);
+      return { data: data as DetailCostWithRelations[] };
+    } catch (error) {
+      console.error('❌ [costsApi.getAll] failed:', error);
+      return { error: handleSupabaseError(error, 'Get cost details') };
+    }
+  },
+
+  // Fetch all cost categories
+  async getCategories(): Promise<ApiResponse<CostCategory[]>> {
+    console.log('🚀 [costsApi.getCategories] called');
+    try {
+      const { data, error } = await supabase
+        .from('cost_categories')
+        .select('*')
+        .order('name');
+
+      if (error) {
+        console.error('❌ [costsApi.getCategories] failed:', error);
+        return { error: handleSupabaseError(error, 'Get cost categories') };
+      }
+
+      console.log('✅ [costsApi.getCategories] completed:', data);
+      return { data: data as CostCategory[] };
+    } catch (error) {
+      console.error('❌ [costsApi.getCategories] failed:', error);
+      return { error: handleSupabaseError(error, 'Get cost categories') };
+    }
+  },
+
+  // Fetch all locations
+  async getLocations(): Promise<ApiResponse<Location[]>> {
+    console.log('🚀 [costsApi.getLocations] called');
+    try {
+      const { data, error } = await supabase
+        .from('location')
+        .select('*')
+        .order('city');
+
+      if (error) {
+        console.error('❌ [costsApi.getLocations] failed:', error);
+        return { error: handleSupabaseError(error, 'Get locations') };
+      }
+
+      console.log('✅ [costsApi.getLocations] completed:', data);
+      return { data: data as Location[] };
+    } catch (error) {
+      console.error('❌ [costsApi.getLocations] failed:', error);
+      return { error: handleSupabaseError(error, 'Get locations') };
+    }
+  },
+
+  // Create cost category
+  async createCategory(payload: CostCategoryInsert): Promise<ApiResponse<CostCategory>> {
+    console.log('🚀 [costsApi.createCategory] called with:', payload);
+    try {
+      const { data, error } = await supabase
+        .from('cost_categories')
+        .insert(payload)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ [costsApi.createCategory] failed:', error);
+        return { error: handleSupabaseError(error, 'Create cost category') };
+      }
+
+      console.log('✅ [costsApi.createCategory] completed:', data);
+      return { data };
+    } catch (error) {
+      console.error('❌ [costsApi.createCategory] failed:', error);
+      return { error: handleSupabaseError(error, 'Create cost category') };
+    }
+  },
+
+  // Create location
+  async createLocation(payload: LocationInsert): Promise<ApiResponse<Location>> {
+    console.log('🚀 [costsApi.createLocation] called with:', payload);
+    try {
+      const { data, error } = await supabase
+        .from('location')
+        .insert(payload)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ [costsApi.createLocation] failed:', error);
+        return { error: handleSupabaseError(error, 'Create location') };
+      }
+
+      console.log('✅ [costsApi.createLocation] completed:', data);
+      return { data };
+    } catch (error) {
+      console.error('❌ [costsApi.createLocation] failed:', error);
+      return { error: handleSupabaseError(error, 'Create location') };
+    }
+  },
+
+  // Create detail cost category
+  async createDetail(payload: DetailCostCategoryInsert): Promise<ApiResponse<DetailCostCategory>> {
+    console.log('🚀 [costsApi.createDetail] called with:', payload);
+    try {
+      const { data, error } = await supabase
+        .from('detail_cost_categories')
+        .insert(payload)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ [costsApi.createDetail] failed:', error);
+        return { error: handleSupabaseError(error, 'Create cost detail') };
+      }
+
+      console.log('✅ [costsApi.createDetail] completed:', data);
+      return { data };
+    } catch (error) {
+      console.error('❌ [costsApi.createDetail] failed:', error);
+      return { error: handleSupabaseError(error, 'Create cost detail') };
+    }
+  },
+};
+

--- a/src/lib/supabase/api/index.ts
+++ b/src/lib/supabase/api/index.ts
@@ -14,3 +14,4 @@ export { usersApi } from './users';
 export { clientWorksApi } from './client-works';
 export { subscriptions } from './subscriptions';
 export { workMaterialLinksApi } from './work-material-links';
+export { costsApi } from './costs';

--- a/src/lib/supabase/types/costs.ts
+++ b/src/lib/supabase/types/costs.ts
@@ -1,0 +1,22 @@
+/**
+ * Construction Cost Types
+ * Defines types for cost categories, detailed costs and locations
+ */
+
+import type { Database } from './database';
+
+export type CostCategory = Database['public']['Tables']['cost_categories']['Row'];
+export type CostCategoryInsert = Database['public']['Tables']['cost_categories']['Insert'];
+
+export type DetailCostCategory = Database['public']['Tables']['detail_cost_categories']['Row'];
+export type DetailCostCategoryInsert = Database['public']['Tables']['detail_cost_categories']['Insert'];
+
+export type Location = Database['public']['Tables']['location']['Row'];
+export type LocationInsert = Database['public']['Tables']['location']['Insert'];
+
+// Extended type combining related entities
+export interface DetailCostWithRelations extends DetailCostCategory {
+  cost_categories?: CostCategory;
+  location?: Location;
+}
+

--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -473,4 +473,100 @@ export type DatabaseTables = {
       }
     ];
   };
+  cost_categories: {
+    Row: {
+      id: string;
+      code: string | null;
+      name: string;
+      unit: string | null;
+      description: string | null;
+      created_at: string | null;
+    };
+    Insert: {
+      id?: string;
+      code?: string | null;
+      name: string;
+      unit?: string | null;
+      description?: string | null;
+      created_at?: string;
+    };
+    Update: {
+      id?: string;
+      code?: string | null;
+      name?: string;
+      unit?: string | null;
+      description?: string | null;
+      created_at?: string;
+    };
+    Relationships: [];
+  };
+  location: {
+    Row: {
+      id: string;
+      country: string | null;
+      region: string | null;
+      city: string | null;
+      created_at: string | null;
+    };
+    Insert: {
+      id?: string;
+      country?: string | null;
+      region?: string | null;
+      city?: string | null;
+      created_at?: string;
+    };
+    Update: {
+      id?: string;
+      country?: string | null;
+      region?: string | null;
+      city?: string | null;
+      created_at?: string;
+    };
+    Relationships: [];
+  };
+  detail_cost_categories: {
+    Row: {
+      id: string;
+      cost_category_id: string;
+      location_id: string;
+      name: string;
+      unit: string | null;
+      unit_cost: number | null;
+      created_at: string | null;
+    };
+    Insert: {
+      id?: string;
+      cost_category_id: string;
+      location_id: string;
+      name: string;
+      unit?: string | null;
+      unit_cost?: number | null;
+      created_at?: string;
+    };
+    Update: {
+      id?: string;
+      cost_category_id?: string;
+      location_id?: string;
+      name?: string;
+      unit?: string | null;
+      unit_cost?: number | null;
+      created_at?: string;
+    };
+    Relationships: [
+      {
+        foreignKeyName: 'detail_cost_categories_cost_category_id_fkey';
+        columns: ['cost_category_id'];
+        isOneToOne: false;
+        referencedRelation: 'cost_categories';
+        referencedColumns: ['id'];
+      },
+      {
+        foreignKeyName: 'detail_cost_categories_location_id_fkey';
+        columns: ['location_id'];
+        isOneToOne: false;
+        referencedRelation: 'location';
+        referencedColumns: ['id'];
+      }
+    ];
+  };
 };

--- a/src/lib/supabase/types/index.ts
+++ b/src/lib/supabase/types/index.ts
@@ -11,3 +11,4 @@ export * from './boq';
 export * from './library';
 export * from './api';
 export * from './ui';
+export * from './costs';

--- a/src/pages/admin/ConstructionCostsPage.tsx
+++ b/src/pages/admin/ConstructionCostsPage.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Typography, Form, Input, Button, Table, Select, InputNumber, message } from 'antd';
+import * as XLSX from 'xlsx';
+import type {
+  CostCategory,
+  Location,
+  DetailCostWithRelations,
+  CostCategoryInsert,
+  LocationInsert,
+  DetailCostCategoryInsert,
+} from '../../lib/supabase/types';
+import { costsApi } from '../../lib/supabase/api';
+
+const { Title } = Typography;
+
+const ConstructionCostsPage: React.FC = () => {
+  const [categories, setCategories] = useState<CostCategory[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [details, setDetails] = useState<DetailCostWithRelations[]>([]);
+
+  const loadData = async () => {
+    console.log('🚀 [ConstructionCostsPage.loadData] called');
+    const { data: detailData, error: detailError } = await costsApi.getAll();
+    if (detailError) {
+      console.error('❌ [ConstructionCostsPage.loadData] failed:', detailError);
+      message.error(detailError);
+      return;
+    }
+    setDetails(detailData || []);
+
+    const { data: catData } = await costsApi.getCategories();
+    if (catData) setCategories(catData);
+
+    const { data: locData } = await costsApi.getLocations();
+    if (locData) setLocations(locData);
+
+    console.log('✅ [ConstructionCostsPage.loadData] completed');
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const onCreateCategory = async (values: CostCategoryInsert) => {
+    console.log('🚀 [onCreateCategory] called with:', values);
+    const { data, error } = await costsApi.createCategory(values);
+    if (error) {
+      console.error('❌ [onCreateCategory] failed:', error);
+      return message.error(error);
+    }
+    setCategories(prev => [...prev, data!]);
+    message.success('Категория создана');
+    console.log('✅ [onCreateCategory] completed:', data);
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    console.log('🚀 [ConstructionCostsPage.handleImport] called with:', file.name);
+    try {
+      const data = await file.arrayBuffer();
+      const workbook = XLSX.read(data);
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows = XLSX.utils.sheet_to_json<string[]>(sheet, { header: 1 }) as string[][];
+
+      for (const row of rows.slice(1)) {
+        const [code, categoryName, categoryUnit, detailName, detailUnit, locationName] = row;
+        if (!categoryName || !detailName || !locationName) continue;
+
+        let category = categories.find(c => c.name === categoryName);
+        if (!category) {
+          const { data: newCat } = await costsApi.createCategory({
+            code: code || null,
+            name: categoryName,
+            unit: categoryUnit || null,
+          });
+          if (newCat) {
+            setCategories(prev => [...prev, newCat]);
+            category = newCat;
+          }
+        }
+
+        let location = locations.find(l => l.city === locationName);
+        if (!location) {
+          const { data: newLoc } = await costsApi.createLocation({ city: locationName });
+          if (newLoc) {
+            setLocations(prev => [...prev, newLoc]);
+            location = newLoc;
+          }
+        }
+
+        if (!category || !location) continue;
+
+        await costsApi.createDetail({
+          cost_category_id: category.id,
+          location_id: location.id,
+          name: detailName,
+          unit: detailUnit || null,
+        });
+      }
+
+      await loadData();
+      message.success('Импорт завершён');
+      console.log('✅ [ConstructionCostsPage.handleImport] completed');
+    } catch (error) {
+      console.error('❌ [ConstructionCostsPage.handleImport] failed:', error);
+      message.error('Ошибка импорта');
+    }
+  };
+
+  const onCreateLocation = async (values: LocationInsert) => {
+    console.log('🚀 [onCreateLocation] called with:', values);
+    const { data, error } = await costsApi.createLocation(values);
+    if (error) {
+      console.error('❌ [onCreateLocation] failed:', error);
+      return message.error(error);
+    }
+    setLocations(prev => [...prev, data!]);
+    message.success('Локация создана');
+    console.log('✅ [onCreateLocation] completed:', data);
+  };
+
+  const onCreateDetail = async (values: DetailCostCategoryInsert) => {
+    console.log('🚀 [onCreateDetail] called with:', values);
+    const { error } = await costsApi.createDetail(values);
+    if (error) {
+      console.error('❌ [onCreateDetail] failed:', error);
+      return message.error(error);
+    }
+    await loadData();
+    message.success('Детализация добавлена');
+    console.log('✅ [onCreateDetail] completed');
+  };
+
+  return (
+    <div className="w-full min-h-full bg-gray-50">
+      <div className="bg-white px-6 py-6 border-b border-gray-200">
+        <div className="max-w-none">
+          <Title level={2}>Затраты на строительство</Title>
+        </div>
+      </div>
+
+      <div className="p-6 space-y-6 max-w-none">
+        <Card title="Добавить категорию">
+          <Form layout="inline" onFinish={onCreateCategory}>
+            <Form.Item name="code"> <Input placeholder="Номер" /> </Form.Item>
+            <Form.Item name="name" rules={[{ required: true, message: 'Введите название' }]}> <Input placeholder="Название" /> </Form.Item>
+            <Form.Item name="unit"> <Input placeholder="Ед. изм." /> </Form.Item>
+            <Form.Item name="description"> <Input placeholder="Описание" /> </Form.Item>
+            <Form.Item> <Button type="primary" htmlType="submit">Сохранить</Button> </Form.Item>
+          </Form>
+        </Card>
+
+        <Card title="Добавить локацию">
+          <Form layout="inline" onFinish={onCreateLocation}>
+            <Form.Item name="country"> <Input placeholder="Страна" /> </Form.Item>
+            <Form.Item name="region"> <Input placeholder="Регион" /> </Form.Item>
+            <Form.Item name="city"> <Input placeholder="Город" /> </Form.Item>
+            <Form.Item> <Button type="primary" htmlType="submit">Сохранить</Button> </Form.Item>
+          </Form>
+        </Card>
+
+        <Card title="Добавить детализацию">
+          <Form layout="inline" onFinish={onCreateDetail}>
+            <Form.Item name="cost_category_id" rules={[{ required: true, message: 'Категория' }]}> <Select placeholder="Категория" style={{ width: 200 }}>{categories.map(c => (<Select.Option key={c.id} value={c.id}>{c.name}</Select.Option>))}</Select> </Form.Item>
+            <Form.Item name="location_id" rules={[{ required: true, message: 'Локация' }]}> <Select placeholder="Локация" style={{ width: 200 }}>{locations.map(l => (<Select.Option key={l.id} value={l.id}>{l.country} {l.city}</Select.Option>))}</Select> </Form.Item>
+            <Form.Item name="name" rules={[{ required: true, message: 'Название' }]}> <Input placeholder="Название" /> </Form.Item>
+            <Form.Item name="unit"> <Input placeholder="Ед. изм." /> </Form.Item>
+            <Form.Item name="unit_cost"> <InputNumber placeholder="Стоимость" /> </Form.Item>
+            <Form.Item> <Button type="primary" htmlType="submit">Сохранить</Button> </Form.Item>
+          </Form>
+        </Card>
+
+        <Card title="Импорт из Excel">
+          <input type="file" accept=".xlsx" onChange={handleImport} />
+        </Card>
+
+        <Card title="Детализация затрат">
+          <Table
+            dataSource={details}
+            rowKey="id"
+            columns={[
+              { title: 'Категория', dataIndex: ['cost_categories', 'name'] },
+              { title: 'Деталь', dataIndex: 'name' },
+              { title: 'Ед. изм.', dataIndex: 'unit' },
+              { title: 'Стоимость', dataIndex: 'unit_cost' },
+              {
+                title: 'Локация',
+                render: (_: unknown, record: DetailCostWithRelations) => `${record.location?.country || ''} ${record.location?.city || ''}`,
+              },
+            ]}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ConstructionCostsPage;
+

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -3287,7 +3287,38 @@ CREATE INDEX identities_user_id_idx ON auth.identities USING btree (user_id);
 -- Index on auth.mfa_amr_claims
 CREATE UNIQUE INDEX amr_id_pk ON auth.mfa_amr_claims USING btree (id);
 
--- Index on auth.mfa_challenges
+CREATE UNIQUE INDEX secrets_name_idx ON vault.secrets USING btree (name) WHERE (name IS NOT NULL);
+
+-- Construction Cost Tables
+create table if not exists public.cost_categories (
+    id uuid primary key default gen_random_uuid(),
+    code text,
+    name text not null,
+    unit text,
+    description text,
+    created_at timestamptz default now()
+);
+
+create table if not exists public.location (
+    id uuid primary key default gen_random_uuid(),
+    country text,
+    region text,
+    city text,
+    created_at timestamptz default now()
+);
+
+create table if not exists public.detail_cost_categories (
+    id uuid primary key default gen_random_uuid(),
+    cost_category_id uuid not null references public.cost_categories(id) on delete cascade,
+    location_id uuid not null references public.location(id) on delete cascade,
+    name text not null,
+    unit text,
+    unit_cost numeric(12,2),
+    created_at timestamptz default now()
+);
+
+create index if not exists detail_cost_categories_cost_category_id_idx on public.detail_cost_categories(cost_category_id);
+create index if not exists detail_cost_categories_location_id_idx on public.detail_cost_categories(location_id);
 CREATE INDEX mfa_challenge_created_at_idx ON auth.mfa_challenges USING btree (created_at DESC);
 
 -- Index on auth.mfa_factors


### PR DESCRIPTION
## Summary
- добавить код и единицы измерения в таблицы затрат
- реализовать загрузку затрат из Excel и отдельные запросы категорий и локаций
- обновить страницу администрирования с поддержкой импорта

## Testing
- `npm run lint` *(fails: Tag is defined but never used, Unexpected any, etc.)*
- `npm run build` *(fails: Property 'base_price' does not exist, 'status' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689c8eee5fc8832eb219f81dfe3bb989