### PR TITLE
Добавлен импорт Excel для страницы "Затраты на строительство"

### DIFF
--- a/src/lib/supabase/api/costs.ts
+++ b/src/lib/supabase/api/costs.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../client';
+import * as XLSX from 'xlsx';
 import type {
   CostCategory,
   CostCategoryInsert,
@@ -103,5 +104,136 @@ export const costsApi = {
       return { error: handleSupabaseError(error, 'Create cost detail') };
     }
   },
+
+  // Import cost categories, details and locations from Excel
+  async importFromXlsx(
+    file: File,
+    onProgress?: (progress: number, step: string) => void
+  ): Promise<ApiResponse<{ rows: number }>> {
+    console.log('🚀 [costsApi.importFromXlsx] called with:', { fileName: file.name });
+    try {
+      onProgress?.(10, 'Чтение Excel файла...');
+      const data = await file.arrayBuffer();
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      onProgress?.(25, 'Парсинг данных из Excel...');
+      const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+        header: [
+          'cat_number',
+          'cat_name',
+          'cat_unit',
+          'detail_name',
+          'detail_unit',
+          'location'
+        ],
+        range: 1,
+        defval: '',
+        raw: false
+      });
+
+      console.log('📊 [costsApi.importFromXlsx] parsed rows:', rows.slice(0, 3));
+      onProgress?.(40, 'Подготовка данных...');
+
+      // Load existing categories and locations
+      const { data: existingCats, error: catsError } = await supabase
+        .from('cost_categories')
+        .select('id, name');
+      if (catsError) throw catsError;
+      const categoryMap = new Map<string, string>();
+      existingCats?.forEach(cat => categoryMap.set(cat.name, cat.id));
+
+      const { data: existingLocs, error: locError } = await supabase
+        .from('location')
+        .select('id, country, region, city');
+      if (locError) throw locError;
+      const locationMap = new Map<string, string>();
+      existingLocs?.forEach(loc => {
+        const key = [loc.country, loc.region, loc.city].filter(Boolean).join(', ');
+        locationMap.set(key, loc.id);
+      });
+
+      const newCategories: { name: string; description?: string | null }[] = [];
+      const newLocations: { country?: string | null; region?: string | null; city?: string | null }[] = [];
+
+      rows.forEach(row => {
+        const catName = `${String(row.cat_number).trim()} ${String(row.cat_name).trim()}`.trim();
+        if (catName && !categoryMap.has(catName)) {
+          newCategories.push({
+            name: catName,
+            description: String(row.cat_unit).trim() || null
+          });
+          categoryMap.set(catName, 'temp');
+        }
+
+        const locationStr = String(row.location).trim();
+        if (locationStr && !locationMap.has(locationStr)) {
+          const parts = locationStr.split(',').map(p => p.trim());
+          const [country, region, city] = [parts[0] || null, parts[1] || null, parts[2] || null];
+          newLocations.push({ country, region, city });
+          locationMap.set(locationStr, 'temp');
+        }
+      });
+
+      if (newCategories.length) {
+        onProgress?.(60, 'Сохранение категорий...');
+        const { data: insertedCats, error } = await supabase
+          .from('cost_categories')
+          .insert(newCategories)
+          .select('id, name');
+        if (error) throw error;
+        insertedCats?.forEach(cat => categoryMap.set(cat.name, cat.id));
+      }
+
+      if (newLocations.length) {
+        onProgress?.(70, 'Сохранение локаций...');
+        const { data: insertedLocs, error } = await supabase
+          .from('location')
+          .insert(newLocations)
+          .select('id, country, region, city');
+        if (error) throw error;
+        insertedLocs?.forEach(loc => {
+          const key = [loc.country, loc.region, loc.city].filter(Boolean).join(', ');
+          locationMap.set(key, loc.id);
+        });
+      }
+
+      onProgress?.(85, 'Сохранение детализаций...');
+      const detailRows = rows
+        .map(row => {
+          const catName = `${String(row.cat_number).trim()} ${String(row.cat_name).trim()}`.trim();
+          const detailName = String(row.detail_name).trim();
+          if (!catName || !detailName) return null;
+          const locationStr = String(row.location).trim();
+          const catId = categoryMap.get(catName);
+          const locId = locationMap.get(locationStr);
+          if (!catId || !locId) return null;
+          const name = row.detail_unit
+            ? `${detailName} (${String(row.detail_unit).trim()})`
+            : detailName;
+          return {
+            cost_category_id: catId,
+            location_id: locId,
+            name,
+            unit_cost: null
+          } as DetailCostCategoryInsert;
+        })
+        .filter(Boolean) as DetailCostCategoryInsert[];
+
+      if (detailRows.length) {
+        const { error } = await supabase
+          .from('detail_cost_categories')
+          .insert(detailRows);
+        if (error) throw error;
+      }
+
+      onProgress?.(100, 'Импорт завершен');
+      console.log('✅ [costsApi.importFromXlsx] completed:', { rows: rows.length });
+      return { data: { rows: rows.length } };
+    } catch (error) {
+      console.error('❌ [costsApi.importFromXlsx] failed:', error);
+      return { error: handleSupabaseError(error, 'Import costs from Excel') };
+    }
+  }
 };
 

--- a/src/pages/admin/ConstructionCostsPage.tsx
+++ b/src/pages/admin/ConstructionCostsPage.tsx
@@ -9,6 +9,7 @@ import type {
   DetailCostCategoryInsert,
 } from '../../lib/supabase/types';
 import { costsApi } from '../../lib/supabase/api';
+import CostExcelUpload from './components/CostExcelUpload';
 
 const { Title } = Typography;
 
@@ -82,6 +83,10 @@ const ConstructionCostsPage: React.FC = () => {
       </div>
 
       <div className="p-6 space-y-6 max-w-none">
+        <Card title="Импорт из Excel">
+          <CostExcelUpload onUploaded={loadData} />
+        </Card>
+
         <Card title="Добавить категорию">
           <Form layout="inline" onFinish={onCreateCategory}>
             <Form.Item name="name" rules={[{ required: true, message: 'Введите название' }]}> <Input placeholder="Название" /> </Form.Item>

--- a/src/pages/admin/components/CostExcelUpload.tsx
+++ b/src/pages/admin/components/CostExcelUpload.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Upload, Button, message } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
+import type { UploadProps } from 'antd';
+import type { UploadRequestOption as RcUploadRequestOption } from 'rc-upload/lib/interface';
+import UploadProgressModal from '../../../components/common/UploadProgressModal';
+import { costsApi } from '../../../lib/supabase/api';
+
+interface CostExcelUploadProps {
+  onUploaded?: () => void;
+}
+
+const CostExcelUpload: React.FC<CostExcelUploadProps> = ({ onUploaded }) => {
+  const [uploadState, setUploadState] = useState({
+    visible: false,
+    progress: 0,
+    fileName: '',
+    currentStep: '',
+    startTime: 0,
+    elapsedTime: 0,
+    isCompleted: false
+  });
+
+  console.log('🚀 [CostExcelUpload] rendered');
+
+  const uploadProps: UploadProps = {
+    showUploadList: false,
+    accept: '.xlsx,.xls',
+    customRequest: async (options: RcUploadRequestOption) => {
+      const { file, onError, onSuccess } = options;
+      const excelFile = file as File;
+
+      console.log('📤 [CostExcelUpload] upload started:', excelFile.name);
+
+      try {
+        const startTime = Date.now();
+        setUploadState({
+          visible: true,
+          progress: 0,
+          fileName: excelFile.name,
+          currentStep: 'Начало загрузки...',
+          startTime,
+          elapsedTime: 0,
+          isCompleted: false
+        });
+
+        const timer = setInterval(() => {
+          const elapsed = (Date.now() - startTime) / 1000;
+          setUploadState(prev => ({ ...prev, elapsedTime: elapsed }));
+        }, 100);
+
+        const result = await costsApi.importFromXlsx(
+          excelFile,
+          (progress: number, step: string) => {
+            console.log('📈 [CostExcelUpload] progress:', { progress, step });
+            setUploadState(prev => ({ ...prev, progress, currentStep: step }));
+          }
+        );
+
+        clearInterval(timer);
+
+        if (result.error) {
+          console.error('❌ [CostExcelUpload] failed:', result.error);
+          setUploadState(prev => ({ ...prev, visible: false }));
+          message.error(`Ошибка: ${result.error}`);
+          onError?.(new Error(result.error));
+          return;
+        }
+
+        setUploadState(prev => ({ ...prev, isCompleted: true }));
+
+        onSuccess?.(result, new XMLHttpRequest());
+
+        setTimeout(() => {
+          setUploadState(prev => ({ ...prev, visible: false }));
+          message.success('Импорт завершен');
+          onUploaded?.();
+        }, 1500);
+      } catch (error) {
+        console.error('💥 [CostExcelUpload] exception:', error);
+        setUploadState(prev => ({ ...prev, visible: false }));
+        message.error('Ошибка при загрузке файла');
+        onError?.(error as Error);
+      }
+    }
+  };
+
+  return (
+    <>
+      <Upload {...uploadProps}>
+        <Button size="small" icon={<UploadOutlined />} disabled={uploadState.visible}>
+          {uploadState.visible ? 'Загрузка...' : 'Загрузить Excel'}
+        </Button>
+      </Upload>
+      <UploadProgressModal
+        visible={uploadState.visible}
+        progress={uploadState.progress}
+        fileName={uploadState.fileName}
+        currentStep={uploadState.currentStep}
+        elapsedTime={uploadState.elapsedTime}
+        isCompleted={uploadState.isCompleted}
+        onClose={() => {
+          if (uploadState.isCompleted) {
+            setUploadState(prev => ({ ...prev, visible: false }));
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default CostExcelUpload;
+


### PR DESCRIPTION
## Summary
- добавлен API метод `importFromXlsx` для импорта категорий, локаций и детализаций из Excel
- реализован компонент `CostExcelUpload` с прогрессом загрузки
- интегрирован импорт на страницу `Затраты на строительство`

## Testing
- `npm run lint` *(failed: 216 problems)*
- `npm run build` *(failed: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c95e85714832ea664c66988ec10de