### PR TITLE
feat: импорт затрат из excel

### DIFF
--- a/src/lib/supabase/api/costs.ts
+++ b/src/lib/supabase/api/costs.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../client';
+import * as XLSX from 'xlsx';
 import type {
   CostCategory,
   CostCategoryInsert,
@@ -101,6 +102,93 @@ export const costsApi = {
     } catch (error) {
       console.error('❌ [costsApi.createDetail] failed:', error);
       return { error: handleSupabaseError(error, 'Create cost detail') };
+    }
+  },
+
+  // Import cost data from Excel file
+  async importFromXlsx(file: File): Promise<ApiResponse<{ rows: number }>> {
+    console.log('🚀 [costsApi.importFromXlsx] called with:', { fileName: file.name });
+    try {
+      console.log('📖 Reading Excel file...');
+      const buffer = await file.arrayBuffer();
+      const workbook = XLSX.read(buffer, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+        header: ['cat_code', 'cat_name', 'cat_unit', 'detail_name', 'detail_unit', 'location'],
+        range: 1,
+        raw: false,
+        defval: ''
+      });
+
+      console.log('📊 Raw rows:', rows.slice(0, 3));
+      const validRows = rows.filter(r => r.cat_name && r.detail_name);
+      console.log('📈 Valid rows:', validRows.length);
+
+      const categoriesMap = new Map<string, CostCategoryInsert>();
+      const locationsMap = new Map<string, LocationInsert>();
+
+      validRows.forEach(r => {
+        const code = String(r.cat_code || '').trim();
+        const name = String(r.cat_name || '').trim();
+        const unit = String(r.cat_unit || '').trim();
+        if (name && !categoriesMap.has(code)) {
+          categoriesMap.set(code, { code: code || null, name, unit: unit || null });
+        }
+        const loc = String(r.location || '').trim();
+        if (loc && !locationsMap.has(loc)) {
+          locationsMap.set(loc, { city: loc });
+        }
+      });
+
+      console.log('📡 Upserting categories:', categoriesMap.size);
+      const { data: catData, error: catError } = await supabase
+        .from('cost_categories')
+        .upsert(Array.from(categoriesMap.values()), { onConflict: 'code' })
+        .select();
+      if (catError) {
+        console.error('❌ [costsApi.importFromXlsx] category upsert failed:', catError);
+        return { error: handleSupabaseError(catError, 'Import categories') };
+      }
+
+      console.log('📡 Upserting locations:', locationsMap.size);
+      const { data: locData, error: locError } = await supabase
+        .from('location')
+        .upsert(Array.from(locationsMap.values()), { onConflict: 'city' })
+        .select();
+      if (locError) {
+        console.error('❌ [costsApi.importFromXlsx] location upsert failed:', locError);
+        return { error: handleSupabaseError(locError, 'Import locations') };
+      }
+
+      const catIdByCode = new Map<string, string>();
+      catData?.forEach(c => catIdByCode.set(c.code || '', c.id));
+      const locIdByName = new Map<string, string>();
+      locData?.forEach(l => locIdByName.set(l.city || '', l.id));
+
+      const details: DetailCostCategoryInsert[] = validRows
+        .map(r => ({
+          cost_category_id: catIdByCode.get(String(r.cat_code || '').trim())!,
+          location_id: locIdByName.get(String(r.location || '').trim())!,
+          name: String(r.detail_name || '').trim(),
+          unit: String(r.detail_unit || '').trim() || null,
+        }))
+        .filter(d => d.cost_category_id && d.location_id && d.name);
+
+      console.log('📡 Inserting details:', details.length);
+      const { error: detailError } = await supabase
+        .from('detail_cost_categories')
+        .insert(details);
+      if (detailError) {
+        console.error('❌ [costsApi.importFromXlsx] detail insert failed:', detailError);
+        return { error: handleSupabaseError(detailError, 'Import details') };
+      }
+
+      console.log('✅ [costsApi.importFromXlsx] completed:', { rows: details.length });
+      return { data: { rows: details.length } };
+    } catch (error) {
+      console.error('❌ [costsApi.importFromXlsx] failed:', error);
+      return { error: handleSupabaseError(error, 'Import costs from Excel') };
     }
   },
 };

--- a/src/lib/supabase/types/database/tables.ts
+++ b/src/lib/supabase/types/database/tables.ts
@@ -476,19 +476,25 @@ export type DatabaseTables = {
   cost_categories: {
     Row: {
       id: string;
+      code: string | null;
       name: string;
+      unit: string | null;
       description: string | null;
       created_at: string | null;
     };
     Insert: {
       id?: string;
+      code?: string | null;
       name: string;
+      unit?: string | null;
       description?: string | null;
       created_at?: string;
     };
     Update: {
       id?: string;
+      code?: string | null;
       name?: string;
+      unit?: string | null;
       description?: string | null;
       created_at?: string;
     };
@@ -524,6 +530,7 @@ export type DatabaseTables = {
       cost_category_id: string;
       location_id: string;
       name: string;
+      unit: string | null;
       unit_cost: number | null;
       created_at: string | null;
     };
@@ -532,6 +539,7 @@ export type DatabaseTables = {
       cost_category_id: string;
       location_id: string;
       name: string;
+      unit?: string | null;
       unit_cost?: number | null;
       created_at?: string;
     };
@@ -540,6 +548,7 @@ export type DatabaseTables = {
       cost_category_id?: string;
       location_id?: string;
       name?: string;
+      unit?: string | null;
       unit_cost?: number | null;
       created_at?: string;
     };

--- a/src/pages/admin/ConstructionCostsPage.tsx
+++ b/src/pages/admin/ConstructionCostsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Typography, Form, Input, Button, Table, Select, InputNumber, message } from 'antd';
+import { Card, Typography, Form, Input, Button, Table, Select, InputNumber, message, Upload } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
 import type {
   CostCategory,
   Location,
@@ -107,6 +108,28 @@ const ConstructionCostsPage: React.FC = () => {
             <Form.Item name="unit_cost"> <InputNumber placeholder="Стоимость" /> </Form.Item>
             <Form.Item> <Button type="primary" htmlType="submit">Сохранить</Button> </Form.Item>
           </Form>
+        </Card>
+
+        <Card title="Импорт из Excel">
+          <Upload
+            accept=".xlsx,.xls"
+            showUploadList={false}
+            beforeUpload={async file => {
+              console.log('🚀 [ConstructionCostsPage.import] called with:', file.name);
+              const { error } = await costsApi.importFromXlsx(file as File);
+              if (error) {
+                console.error('❌ [ConstructionCostsPage.import] failed:', error);
+                message.error(error);
+              } else {
+                message.success('Импорт завершен');
+                await loadData();
+                console.log('✅ [ConstructionCostsPage.import] completed');
+              }
+              return false;
+            }}
+          >
+            <Button icon={<UploadOutlined />}>Загрузить файл</Button>
+          </Upload>
         </Card>
 
         <Card title="Детализация затрат">

--- a/supabase/schemas/prod.sql
+++ b/supabase/schemas/prod.sql
@@ -3066,6 +3066,12 @@ CREATE OR REPLACE FUNCTION storage.search_v2(prefix text, bucket_name text, limi
  RETURNS TABLE(key text, name text, id uuid, updated_at timestamp with time zone, created_at timestamp with time zone, metadata jsonb)
  LANGUAGE plpgsql
  STABLE
+    code text,
+    unit text,
+    unit text,
+create unique index if not exists cost_categories_code_idx on public.cost_categories(code);
+create unique index if not exists location_city_idx on public.location(city);
+
 AS $function$
 BEGIN
     RETURN query EXECUTE


### PR DESCRIPTION
## Summary
- добавить столбцы `code` и `unit` в `cost_categories` и поле `unit` в `detail_cost_categories`
- реализовать импорт Excel в API и на странице "Затраты на строительство"

## Testing
- `npm run lint` *(fails: many pre-existing eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c95e85714832ea664c66988ec10de